### PR TITLE
Add touchpoint flag

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -84,7 +84,7 @@ build_flags =
 build_flags = 
   ${env.build_flags}
   -DFW_VERSION="DEBUG-ETH"
-  -DTOUCHDEBUG
+  -DDEBUG_TOUCH
   -DETH_MODE
   -DETH_SCLK=32
   -DETH_MISO=27
@@ -100,7 +100,7 @@ lib_deps =
 build_flags =
   ${env.build_flags}
   -DFW_VERSION="DEBUG-WIFI"
-  -DTOUCHDEBUG
+  -DDEBUG_TOUCH
   -DWIFI_MODE
 monitor_speed = 115200
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -84,6 +84,7 @@ build_flags =
 build_flags = 
   ${env.build_flags}
   -DFW_VERSION="DEBUG-ETH"
+  -DTOUCHDEBUG
   -DETH_MODE
   -DETH_SCLK=32
   -DETH_MISO=27
@@ -99,6 +100,7 @@ lib_deps =
 build_flags =
   ${env.build_flags}
   -DFW_VERSION="DEBUG-WIFI"
+  -DTOUCHDEBUG
   -DWIFI_MODE
 monitor_speed = 115200
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1635,9 +1635,12 @@ void publishBacklightEvent(int brightness)
     // start lvgl
     lv_init();
     lv_img_cache_set_size(10);
-    String LVGL_Arduino = "[tp32] LVGL starting ";
-    LVGL_Arduino += String('V') + lv_version_major() + "." + lv_version_minor() + "." + lv_version_patch();
-    Serial.println(LVGL_Arduino);
+    Serial.print(F("[tp32] lvgl starting v"));
+    Serial.print(lv_version_major());
+    Serial.print(F("."));
+    Serial.print(lv_version_minor());
+    Serial.print(F("."));
+    Serial.println(lv_version_patch());
 #if LV_USE_LOG != 0
   lv_log_register_print_cb(my_print); // register print function for debugging
 #endif
@@ -1703,7 +1706,7 @@ void publishBacklightEvent(int brightness)
   // show HomeScreen
   screenVault.show(SCREEN_HOME);
 
-  Serial.println("[tp32] Setup done");
+  Serial.println(F("[tp32] Setup done"));
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -480,7 +480,7 @@ void publishBacklightEvent(int brightness)
     data->state = LV_INDEV_STATE_PR;
 
 #if defined(TOUCHDEBUG)
-    Serial.print("Data x,y ");
+    Serial.print("[TP32] Data x,y ");
     Serial.print(data->point.x);
     Serial.print(",");
     Serial.println(data->point.y);
@@ -1620,8 +1620,8 @@ void publishBacklightEvent(int brightness)
   {
     // Start serial and let settle
     Serial.begin(SERIAL_BAUD_RATE);
-    delay(1000);
-    Serial.println(F("[wpan] starting up..."));
+    delay(2000);
+    Serial.println(F("[TP32] starting up..."));
 
     // initialise the Tile_Style_LUT and Img_LUT for later use
     initStyleLut();
@@ -1635,10 +1635,9 @@ void publishBacklightEvent(int brightness)
     // start lvgl
     lv_init();
     lv_img_cache_set_size(10);
-    String LVGL_Arduino = "Hello Arduino! ";
+    String LVGL_Arduino = "[TP32] LVGL starting ";
     LVGL_Arduino += String('V') + lv_version_major() + "." + lv_version_minor() + "." + lv_version_patch();
     Serial.println(LVGL_Arduino);
-    Serial.println("I am LVGL_Arduino");
 #if LV_USE_LOG != 0
   lv_log_register_print_cb(my_print); // register print function for debugging
 #endif
@@ -1692,8 +1691,6 @@ void publishBacklightEvent(int brightness)
   // start the screen to make sure everything is initialised
   ui_init();
 
-  Serial.println("Setup done");
-
   // Start WT32 hardware
   wt32.begin(jsonConfig, jsonCommand);
 
@@ -1705,6 +1702,8 @@ void publishBacklightEvent(int brightness)
 
   // show HomeScreen
   screenVault.show(SCREEN_HOME);
+
+  Serial.println("[TP32] Setup done");
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -480,9 +480,9 @@ void publishBacklightEvent(int brightness)
     data->state = LV_INDEV_STATE_PR;
 
 #if defined(TOUCHDEBUG)
-    Serial.print("[tp32] Data x,y ");
+    Serial.print(F("[tp32] Data x,y "));
     Serial.print(data->point.x);
-    Serial.print(",");
+    Serial.print(F(","));
     Serial.println(data->point.y);
 #endif
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -479,7 +479,7 @@ void publishBacklightEvent(int brightness)
     data->point.y = ts.y;
     data->state = LV_INDEV_STATE_PR;
 
-#if defined(TOUCHDEBUG)
+#if defined(DEBUG_TOUCH)
     Serial.print(F("[tp32] Data x,y "));
     Serial.print(data->point.x);
     Serial.print(F(","));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1237,7 +1237,7 @@ void publishBacklightEvent(int brightness)
 
     // default ON color
     JsonObject color = json.createNestedObject("color");
-    color["title"] = "Defaut Icon Color for ON state.";
+    color["title"] = "Default Icon Color for ON state.";
     color["description"] = "Set your preferred RGB values.(Default [91, 190, 91])";
 
     JsonObject properties4 = color.createNestedObject("properties");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -479,10 +479,12 @@ void publishBacklightEvent(int brightness)
     data->point.y = ts.y;
     data->state = LV_INDEV_STATE_PR;
 
+#if defined(TOUCHDEBUG)
     Serial.print("Data x,y ");
     Serial.print(data->point.x);
     Serial.print(",");
     Serial.println(data->point.y);
+#endif
   }
 
   // check for timeout inactivity timeout

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -480,7 +480,7 @@ void publishBacklightEvent(int brightness)
     data->state = LV_INDEV_STATE_PR;
 
 #if defined(TOUCHDEBUG)
-    Serial.print("[TP32] Data x,y ");
+    Serial.print("[tp32] Data x,y ");
     Serial.print(data->point.x);
     Serial.print(",");
     Serial.println(data->point.y);
@@ -1621,7 +1621,7 @@ void publishBacklightEvent(int brightness)
     // Start serial and let settle
     Serial.begin(SERIAL_BAUD_RATE);
     delay(2000);
-    Serial.println(F("[TP32] starting up..."));
+    Serial.println(F("[tp32] starting up..."));
 
     // initialise the Tile_Style_LUT and Img_LUT for later use
     initStyleLut();
@@ -1635,7 +1635,7 @@ void publishBacklightEvent(int brightness)
     // start lvgl
     lv_init();
     lv_img_cache_set_size(10);
-    String LVGL_Arduino = "[TP32] LVGL starting ";
+    String LVGL_Arduino = "[tp32] LVGL starting ";
     LVGL_Arduino += String('V') + lv_version_major() + "." + lv_version_minor() + "." + lv_version_patch();
     Serial.println(LVGL_Arduino);
 #if LV_USE_LOG != 0
@@ -1703,7 +1703,7 @@ void publishBacklightEvent(int brightness)
   // show HomeScreen
   screenVault.show(SCREEN_HOME);
 
-  Serial.println("[TP32] Setup done");
+  Serial.println("[tp32] Setup done");
 }
 
 /**


### PR DESCRIPTION
added a flag so touchpoint data is only printed on serial in teh debug env - just as a potential security thing if your using keypad

cleaned up a spelling mistake for json schema

and cleaned up the serial debug so it can look a little nicer. and will get slightly better still switching to the wt32 library that i've turned the wt32 class into. (but i'll do this in a different PR)
also increased serial begin delay to give the serial monitor a chance to catch up.

edit: also not sure why github says there is a conflict...