### PR TITLE
add screen footer command (to overwrite screen label)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json
 .vscode/launch.json
+.vscode/settings.json
 .vscode/ipch

--- a/include/classScreen.h
+++ b/include/classScreen.h
@@ -5,7 +5,7 @@ class classScreen
 {
 private:
   lv_obj_t *_parent = NULL;
-  lv_obj_t *_label = NULL;
+  lv_obj_t *_labelFooter = NULL;
   lv_obj_t *_labelWarning = NULL;
   lv_obj_t *_btnHome = NULL;
   lv_obj_t *_btnHomeImg;
@@ -15,6 +15,8 @@ private:
 
 public:
   int screenIdx;
+  char screenLabel[32];
+
   lv_obj_t *screen = NULL;
   lv_obj_t *container = NULL;
 
@@ -23,6 +25,9 @@ public:
   
   void setLabel(const char *labelText);
   const char *getLabel(void);
+  void setFooter(const char *footerText);
+  const char *getFooter(void);
+
   void updateBgColor(void);
   void createHomeButton(lv_event_cb_t callBack, const void *img);
   void createSettingsButton(lv_event_cb_t callBack, const void *img);

--- a/src/classes/classScreen.cpp
+++ b/src/classes/classScreen.cpp
@@ -39,16 +39,17 @@ classScreen::classScreen(int number, int style)
 
     container = cont;
   }
+
   // middle "button" for screen selection drop down
   _btnFooter = lv_imgbtn_create(screen);
   lv_imgbtn_set_src(_btnFooter, LV_IMGBTN_STATE_RELEASED, NULL, NULL, NULL);
   lv_obj_set_size(_btnFooter, 200, 40);
   lv_obj_align(_btnFooter, LV_ALIGN_BOTTOM_MID, 0, 0);
 
-  _label = lv_label_create(screen);
-  lv_obj_align(_label, LV_ALIGN_BOTTOM_MID, 0, -5);
-  lv_obj_set_style_text_font(_label, &lv_font_montserrat_20, 0);
-  lv_label_set_text_fmt(_label, "Screen %d", screenIdx);
+  _labelFooter = lv_label_create(screen);
+  lv_obj_align(_labelFooter, LV_ALIGN_BOTTOM_MID, 0, -5);
+  lv_obj_set_style_text_font(_labelFooter, &lv_font_montserrat_20, 0);
+  lv_label_set_text_fmt(_labelFooter, "Screen %d", screenIdx);
 
   _labelWarning = lv_label_create(screen);
   lv_obj_align(_labelWarning, LV_ALIGN_BOTTOM_RIGHT, -45, -5);
@@ -62,12 +63,31 @@ int classScreen::getScreenNumber(void)
 
 void classScreen::setLabel(const char *labelText)
 {
-  lv_label_set_text(_label, labelText);
+  strcpy(screenLabel, labelText);
+  setFooter(screenLabel);
 }
 
 const char *classScreen::getLabel(void)
 {
-  return lv_label_get_text(_label);
+  return screenLabel;
+}
+
+void classScreen::setFooter(const char *footerText)
+{
+  // if the footer has been cleared, then display the screen label (default)
+  if (strlen(footerText) == 0)
+  {
+    lv_label_set_text(_labelFooter, screenLabel);
+  }
+  else
+  {
+    lv_label_set_text(_labelFooter, footerText);
+  }
+}
+
+const char *classScreen::getFooter(void)
+{
+  return lv_label_get_text(_labelFooter);
 }
 
 void classScreen::updateBgColor(void)

--- a/src/classes/classScreen.cpp
+++ b/src/classes/classScreen.cpp
@@ -49,6 +49,7 @@ classScreen::classScreen(int number, int style)
   _labelFooter = lv_label_create(screen);
   lv_obj_align(_labelFooter, LV_ALIGN_BOTTOM_MID, 0, -5);
   lv_obj_set_style_text_font(_labelFooter, &lv_font_montserrat_20, 0);
+  lv_label_set_recolor(_labelFooter, true);
   lv_label_set_text_fmt(_labelFooter, "Screen %d", screenIdx);
 
   _labelWarning = lv_label_create(screen);


### PR DESCRIPTION
When a screen is first configured the screen label is used for the footer. The backend can then optionally set a custom footer by sending the following `cmnd/` payload;

```json
{"screens": [{"screen":1,"footer":"custom footer"}]}
```

Sending an empty "footer" command will revert the display to the screen label.

This also changes the screen select command from `{"screens":{"load":1}}` to `{"screen":{"load":1}}`. I.e. "screens" -> "screen".