### PR TITLE
enabled footer customisation

### DIFF
--- a/include/classScreen.h
+++ b/include/classScreen.h
@@ -12,10 +12,12 @@ private:
   lv_obj_t *_btnSettings = NULL;
   lv_obj_t *_btnSettingsImg = NULL;
   lv_obj_t *_btnFooter = NULL;
+  lv_obj_t *_labelLeft = NULL;
+  lv_obj_t *_labelCenter = NULL;
+  lv_obj_t *_labelRight = NULL;
 
 public:
   int screenIdx;
-  char screenLabel[32];
 
   lv_obj_t *screen = NULL;
   lv_obj_t *container = NULL;
@@ -25,8 +27,7 @@ public:
   
   void setLabel(const char *labelText);
   const char *getLabel(void);
-  void setFooter(const char *footerText);
-  const char *getFooter(void);
+  void setFooter(const char *left, const char *center, const char *right);
 
   void updateBgColor(void);
   void createHomeButton(lv_event_cb_t callBack, const void *img);

--- a/src/classes/classScreen.cpp
+++ b/src/classes/classScreen.cpp
@@ -49,15 +49,34 @@ classScreen::classScreen(int number, int style)
   _labelFooter = lv_label_create(screen);
   lv_obj_align(_labelFooter, LV_ALIGN_BOTTOM_MID, 0, -5);
   lv_obj_set_style_text_font(_labelFooter, &lv_font_montserrat_20, 0);
+  lv_label_set_text_fmt(_labelFooter, "Screen %d", screenIdx);
   lv_label_set_recolor(_labelFooter, true);
-
-  // default the screen label to something useful
-  sprintf(screenLabel, "Screen %d", screenIdx);
-  setFooter(screenLabel);
 
   _labelWarning = lv_label_create(screen);
   lv_obj_align(_labelWarning, LV_ALIGN_BOTTOM_RIGHT, -45, -5);
   lv_label_set_text(_labelWarning, "");
+
+  // placeholder for footer modifier
+  _labelLeft = lv_label_create(screen);
+  lv_obj_align(_labelLeft, LV_ALIGN_BOTTOM_LEFT, 10, -5);
+  lv_obj_set_style_text_font(_labelLeft, &lv_font_montserrat_20, 0);
+  lv_label_set_text(_labelLeft, "");
+  lv_label_set_recolor(_labelLeft, true);
+  lv_obj_add_flag(_labelLeft, LV_OBJ_FLAG_HIDDEN);
+
+  _labelCenter = lv_label_create(screen);
+  lv_obj_align(_labelCenter, LV_ALIGN_BOTTOM_MID, 0, -5);
+  lv_obj_set_style_text_font(_labelCenter, &lv_font_montserrat_20, 0);
+  lv_label_set_text(_labelCenter, "");
+  lv_label_set_recolor(_labelCenter, true);
+  lv_obj_add_flag(_labelCenter, LV_OBJ_FLAG_HIDDEN);
+
+  _labelRight = lv_label_create(screen);
+  lv_obj_align(_labelRight, LV_ALIGN_BOTTOM_RIGHT, -10, -5);
+  lv_obj_set_style_text_font(_labelRight, &lv_font_montserrat_20, 0);
+  lv_label_set_text(_labelRight, "");
+  lv_label_set_recolor(_labelRight, true);
+  lv_obj_add_flag(_labelRight, LV_OBJ_FLAG_HIDDEN);
 }
 
 int classScreen::getScreenNumber(void)
@@ -67,31 +86,55 @@ int classScreen::getScreenNumber(void)
 
 void classScreen::setLabel(const char *labelText)
 {
-  strcpy(screenLabel, labelText);
-  setFooter(screenLabel);
+  lv_label_set_text(_labelFooter, labelText);
 }
 
 const char *classScreen::getLabel(void)
 {
-  return screenLabel;
+  return lv_label_get_text(_labelFooter);
 }
 
-void classScreen::setFooter(const char *footerText)
+void classScreen::setFooter(const char *left, const char *center, const char *right)
 {
-  // if the footer has been cleared, then display the screen label (default)
-  if (strlen(footerText) == 0)
+  if (!left || (strlen(left) == 0))
   {
-    lv_label_set_text(_labelFooter, screenLabel);
+    lv_obj_add_flag(_labelLeft, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(_btnHome, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(_btnHomeImg, LV_OBJ_FLAG_HIDDEN);
   }
   else
   {
-    lv_label_set_text(_labelFooter, footerText);
+    lv_label_set_text(_labelLeft, left);
+    lv_obj_clear_flag(_labelLeft, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(_btnHome, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(_btnHomeImg, LV_OBJ_FLAG_HIDDEN);
   }
-}
 
-const char *classScreen::getFooter(void)
-{
-  return lv_label_get_text(_labelFooter);
+  if (!center || (strlen(center) == 0))
+  {
+    lv_obj_add_flag(_labelCenter, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(_labelFooter, LV_OBJ_FLAG_HIDDEN);
+  }
+  else
+  {
+    lv_label_set_text(_labelCenter, center);
+    lv_obj_clear_flag(_labelCenter, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(_labelFooter, LV_OBJ_FLAG_HIDDEN);
+  }
+
+  if (!right || (strlen(right) == 0))
+  {
+    lv_obj_add_flag(_labelRight, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(_btnSettings, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(_btnSettingsImg, LV_OBJ_FLAG_HIDDEN);
+  }
+  else
+  {
+    lv_label_set_text(_labelRight, right);
+    lv_obj_clear_flag(_labelRight, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(_btnSettings, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(_btnSettingsImg, LV_OBJ_FLAG_HIDDEN);
+  }
 }
 
 void classScreen::updateBgColor(void)

--- a/src/classes/classScreen.cpp
+++ b/src/classes/classScreen.cpp
@@ -96,7 +96,7 @@ const char *classScreen::getLabel(void)
 
 void classScreen::setFooter(const char *left, const char *center, const char *right)
 {
-  if (!left || (strlen(left) == 0))
+  if (!left)
   {
     lv_obj_add_flag(_labelLeft, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(_btnHome, LV_OBJ_FLAG_HIDDEN);
@@ -110,7 +110,7 @@ void classScreen::setFooter(const char *left, const char *center, const char *ri
     lv_obj_add_flag(_btnHomeImg, LV_OBJ_FLAG_HIDDEN);
   }
 
-  if (!center || (strlen(center) == 0))
+  if (!center)
   {
     lv_obj_add_flag(_labelCenter, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(_labelFooter, LV_OBJ_FLAG_HIDDEN);
@@ -122,7 +122,7 @@ void classScreen::setFooter(const char *left, const char *center, const char *ri
     lv_obj_add_flag(_labelFooter, LV_OBJ_FLAG_HIDDEN);
   }
 
-  if (!right || (strlen(right) == 0))
+  if (!right)
   {
     lv_obj_add_flag(_labelRight, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(_btnSettings, LV_OBJ_FLAG_HIDDEN);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -853,6 +853,12 @@ static void footerButtonEventHandler(lv_event_t * e)
       dropDownOverlay.open();
     }
   }
+  if (event == LV_EVENT_LONG_PRESSED)
+  {
+    // long press of footer center loads hom screen
+    if (lv_obj_has_flag(ta, LV_OBJ_FLAG_USER_2))
+      screenVault.show(SCREEN_HOME);
+  }
 }
 
 // BackLight slider event handler
@@ -1366,7 +1372,7 @@ void jsonScreenCommand(JsonVariant json)
 
   if (json.containsKey("footer"))
   {
-    screen->setFooter(json["footer"]);
+    screen->setFooter(json["footer"][0], json["footer"][1], json["footer"][2]);
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1372,7 +1372,7 @@ void jsonScreenCommand(JsonVariant json)
 
   if (json.containsKey("footer"))
   {
-    screen->setFooter(json["footer"][0], json["footer"][1], json["footer"][2]);
+    screen->setFooter(json["footer"]["left"], json["footer"]["center"], json["footer"]["right"]);
   }
 }
 


### PR DESCRIPTION
each of the 3 footer elements L / C / R can be customised individually

`{"screens":[{"screen":"1", "footer":["left","center","right"]  }]}`

"footer" requires an array of 3 strings in the order [left, center, right]
for each of the array elements (positions L / C / R)
 ` "" ` (empty string) shows the default icon/string
 ` " " `(space) hides the default icon/string
 ` "<any text>"` replaces the default icon/string with `"<any text>"`
an empty arry `"footer":[]` resets all to default
recoloring  like "#ff0000 red#" is enabled for all positions

short press on the footer middle area shows the screen selector pop up
long press on the footer middle area returns to the home screen

closes #10 