### PR TITLE
enable snapshot api (GET /api/snapshot.bin)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -137,6 +137,7 @@ build_flags =
   -DLV_MEM_CUSTOM_FREE=free 
   -DLV_MEM_CUSTOM_REALLOC=ps_realloc
   -DLV_USE_PNG=1
+  -DLV_USE_SNAPSHOT=1
   -DLV_IMG_CACHE_DEF_SIZE=20
   ; -- lvgl logging
   ;-DLV_USE_LOG=1


### PR DESCRIPTION
Requires OXRS-AC-WT32-ESP-LIB [v0.1.0](https://github.com/austinscreations/OXRS-AC-WT32-ESP-LIB/releases/tag/0.1.0) and OXRS-IO-API-ESP32-LIB [v2.4.0](https://github.com/OXRS-IO/OXRS-IO-API-ESP32-LIB/releases/tag/2.4.0)